### PR TITLE
Droneshare login field validation and keyboard release

### DIFF
--- a/Android/src/org/droidplanner/android/fragments/account/DroneshareLoginFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/account/DroneshareLoginFragment.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 public class DroneshareLoginFragment extends Fragment {
 
     private static final String DRONESHARE_PROMPT_ACTION = "droneshare_prompt";
-
+    private static final short DRONESHARE_MIN_PASSWORD = 7;
     private final DroneshareClient dshareClient = new DroneshareClient();
     private DroidPlannerPrefs prefs;
 
@@ -138,21 +138,34 @@ public class DroneshareLoginFragment extends Fragment {
         username.addTextChangedListener(new TextValidator(username) {
             @Override public void validate(TextView textView, String text) {
                 // TODO: validate on acceptable characters, etc
-                if(text.length() == 0) textView.setError("Please enter a username");
+                if(text.length() == 0)
+                    textView.setError("Please enter a username");
+                else
+                    textView.setError(null);
             }
         });
 
         password.addTextChangedListener(new TextValidator(password) {
             @Override public void validate(TextView textView, String text) {
-                // TODO: check for valid length, characters
-                if(text.length() == 0) textView.setError("Please enter a password");
+                if(loginSection.getVisibility() == View.VISIBLE && (
+                    text.length() < 1))
+                    // Since some accounts have been created with < 7 and no digits, allow login
+                    textView.setError("Please enter a password");
+               else if(loginSection.getVisibility() == View.GONE && (
+                        text.length() < DRONESHARE_MIN_PASSWORD || !text.matches(".*\\d+.*")))
+                    // New accounts require at least 7 characters and digit
+                    textView.setError("Use at least 7 characters and one digit");
+                else
+                    textView.setError(null);
             }
         });
 
         email.addTextChangedListener(new TextValidator(email) {
             @Override public void validate(TextView textView, String text) {
-                // TODO: validate on acceptable characters, etc
-                if(text.length() == 0) textView.setError("Please enter an email");
+                if(text.isEmpty() || !android.util.Patterns.EMAIL_ADDRESS.matcher(text).matches())
+                    textView.setError("Please enter a valid email");
+                else
+                    textView.setError(null);
             }
         });
 

--- a/Android/src/org/droidplanner/android/fragments/account/DroneshareLoginFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/account/DroneshareLoginFragment.java
@@ -233,7 +233,7 @@ public class DroneshareLoginFragment extends Fragment {
         }
     }
 
-    public abstract class TextValidator implements TextWatcher {
+    private static abstract class TextValidator implements TextWatcher {
         // Wrapper for TextWatcher, providing a shorthand method of field specific validations
         private final TextView textView;
 

--- a/Android/src/org/droidplanner/android/fragments/account/DroneshareLoginFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/account/DroneshareLoginFragment.java
@@ -2,6 +2,7 @@ package org.droidplanner.android.fragments.account;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -9,6 +10,7 @@ import android.support.v4.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -77,6 +79,8 @@ public class DroneshareLoginFragment extends Fragment {
             public void onClick(View v) {
                 final String usernameText = username.getText().toString();
                 final String passwordText = password.getText().toString();
+                // Hide the soft keyboard, otherwise can remain after logging in.
+                hideSoftInput();
                 new AsyncConnect(false).execute(usernameText, passwordText);
             }
         });
@@ -99,6 +103,10 @@ public class DroneshareLoginFragment extends Fragment {
                 final String usernameText = username.getText().toString();
                 final String passwordText = password.getText().toString();
                 final String emailText = email.getText().toString();
+
+                // Hide the soft keyboard, otherwise can remain after logging in.
+                hideSoftInput();
+
                 new AsyncConnect(true).execute(usernameText, passwordText, emailText);
             }
         });
@@ -158,6 +166,17 @@ public class DroneshareLoginFragment extends Fragment {
 //
 //        GAUtils.sendEvent(eventBuilder);
 //    }
+
+    private void hideSoftInput() {
+        // Get currently focused view and hide soft input.
+        final Activity activity = getActivity();
+        View view = activity.getCurrentFocus();
+        if (view != null) {
+            final InputMethodManager inputManager = (InputMethodManager) activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (inputManager != null)
+                inputManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
+        }
+    }
 
     private class AsyncConnect extends AsyncTask<String, Void, Pair<Boolean, String>> {
 


### PR DESCRIPTION
Adds basic validation to username, password, and email when registering/logging into Droneshare. 

The validation is pretty simple: usernames must be >1 characters. Emails must be .. well, emails. Login/signup is prevented unless the fields validate, and an error icon with an informative message is appended to the invalid field.

Passwords are little more tricky- Droneshare requires at least 7 characters and 1 digit. This hasn't been enforced via account creation using their API however, so DroidPlanner users have been able to create arbitrary passwords. I've added the character and digit restrictions to signup, but allow logging in users to use passwords of any length.

While it's nice to have instant feedback on what you're doing wrong within the app, this creates independent validation rules on the client and server. In the long run, it seems like the server should be responsible for validation.

I also added a method to hide the keyboard after login/signup. If the user hadn't hidden it at time of login, it would stay on screen after loading the Droneshare dashboard.

This is my first contribution to DroidPlanner/Tower (hoorah), figured something harmless would be a good start. Please let me know if I'm stepping on any of your contrib guidelines! :)